### PR TITLE
'work-in-progress' label description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,7 @@ Please open an issue on `Technical-NGO/Technical-NGO.github.io` if you have sugg
 
 | Label name | Description
 | --- | --- |
-| `work-in-progress` |[search][search-technical-ngo-org-label-work-in-progress] | Pull requests which are still being worked on, more changes will follow. |
+| [`work-in-progress`](https://github.com/Technical-NGO/Technical-NGO.github.io/labels/work-in-progress) | Pull requests which are still being worked on, more changes will follow. | [search](search-technical-ngo-org-label-work-in-progress) 
 | `needs-review` | Pull requests which need code review, and approval from maintainers. |
 | `under-review` | Pull requests being reviewed by maintainers.|
 | `requires-changes` | Pull requests which need to be updated based on review comments and then reviewed again. |


### PR DESCRIPTION
Changed the order of the "[search](search-technical-ngo-org-label-work-in-progress) " part as:
1. The file was showing this instead of the description
2. Couldn't understand why you added this, so assumed it was to add a link to search and hence did that (the label doesn't exist yet).

Can anyone confirm/edit this and pull it in? If this was not the intended task, do close this PR